### PR TITLE
Add auto-assign bot and open PR workflow

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,7 @@
+addReviewers: true
+addAssignees: false
+
+reviewers:
+  - dagemdworku
+
+numberOfReviewers: 0

--- a/.github/pr-labeling/branch-name.yml
+++ b/.github/pr-labeling/branch-name.yml
@@ -1,0 +1,5 @@
+feature: ['feature/*', 'feat/*']
+fix: ['fix/*']
+chore: ['chore/*', 'refactor/*']
+test: ['test/*']
+setup: ['setup/*']

--- a/.github/pr-labeling/file-changes.yml
+++ b/.github/pr-labeling/file-changes.yml
@@ -1,0 +1,29 @@
+automation:
+  - any: ['.github/**/*']
+  
+android:
+  - any: ['android/**/*']
+
+ios:
+  - any: ['ios/**/*']
+
+macos:
+  - any: ['macos/**/*']
+
+example:
+  - any: ['example/lib/**/*']
+
+android-example:
+  - any: ['example/android/**/*']
+
+ios-example:
+  - any: ['example/ios/**/*']
+
+macos-example:
+  - any: ['example/macos/**/*']
+
+library:
+  - any: ['lib/**/*']
+
+test:
+  - any: ['test/**/*']

--- a/.github/workflows/open_pr.yml
+++ b/.github/workflows/open_pr.yml
@@ -1,0 +1,34 @@
+name: Pull Request (Opened)
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  assign_author:
+    name: Assign Author to the Pull Request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Assign Author to the Pull Request
+        uses: technote-space/assign-author@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  labeler:
+    name: Label the Pull Request Branch Name
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Label the Pull Request by branch name
+        uses: TimonVS/pr-labeler-action@v4
+        with:
+          configuration-path: .github/pr-labeling/branch-name.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds an auto-assign bot configuration and an open PR workflow to the repository. The auto-assign bot will automatically assign reviewers to pull requests based on the configuration file, while the open PR workflow will label the pull request based on the branch name. This will help streamline the pull request process and ensure that pull requests are reviewed in a timely manner.