### PR TITLE
Edit PR action created

### DIFF
--- a/.github/workflows/edit_pr.yml
+++ b/.github/workflows/edit_pr.yml
@@ -1,0 +1,20 @@
+name: Pull Request (Edited)
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  labeler:
+    name: Label the Pull Request File Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Label the Pull Request by file changes
+        uses: actions/labeler@v4
+        with:
+          configuration-path: .github/pr-labeling/file-changes.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a new GitHub action that allows for editing pull requests. The action is triggered by the `pull_request` event and runs on `ubuntu-latest`. It includes a labeler job that labels the pull request based on the file changes. This will help streamline the pull request review process.