### PR TITLE
Add audio recording functionality to macOS and Flutter packages

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,6 +58,12 @@ class _MyAppState extends State<MyApp> {
                 },
                 child: const Text('Initialize'),
               ),
+              ElevatedButton(
+                onPressed: () async {
+                  await _whisperCppPlugin.toggleRecord();
+                },
+                child: const Text('Toggle Record'),
+              ),
             ],
           ),
         ),

--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/example/macos/Runner/Release.entitlements
+++ b/example/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/lib/whisper_cpp.dart
+++ b/lib/whisper_cpp.dart
@@ -8,4 +8,8 @@ class WhisperCpp {
   Future<void> initialize() {
     return WhisperCppPlatform.instance.initialize();
   }
+
+  Future<void> toggleRecord() {
+    return WhisperCppPlatform.instance.toggleRecord();
+  }
 }

--- a/lib/whisper_cpp_method_channel.dart
+++ b/lib/whisper_cpp_method_channel.dart
@@ -20,4 +20,9 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
   Future<void> initialize() async {
     return await methodChannel.invokeMethod<void>('initialize');
   }
+
+  @override
+  Future<void> toggleRecord() async {
+    return await methodChannel.invokeMethod<void>('toggleRecord');
+  }
 }

--- a/lib/whisper_cpp_platform_interface.dart
+++ b/lib/whisper_cpp_platform_interface.dart
@@ -30,4 +30,8 @@ abstract class WhisperCppPlatform extends PlatformInterface {
   Future<void> initialize() {
     throw UnimplementedError('initialize() has not been implemented.');
   }
+
+  Future<void> toggleRecord() {
+    throw UnimplementedError('toggleRecord() has not been implemented.');
+  }
 }

--- a/macos/Classes/WhisperCppPlugin.swift
+++ b/macos/Classes/WhisperCppPlugin.swift
@@ -17,6 +17,8 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
         case "initialize":
             initialize()
             result(nil)
+        case "toggleRecord":
+            toggleRecord(result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -24,5 +26,20 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
     
     @MainActor private func initialize(){
         whisperState = WhisperState()
+    }
+    
+    @MainActor private func toggleRecord(result: @escaping FlutterResult) {
+        if whisperState == nil {
+            result(nil)
+        } else {
+            Task {
+                do {
+                    await self.whisperState!.toggleRecord()
+                    DispatchQueue.main.async {
+                        result(nil)
+                    }
+                }
+            }
+        }
     }
 }

--- a/test/whisper_cpp_test.dart
+++ b/test/whisper_cpp_test.dart
@@ -12,6 +12,9 @@ class MockWhisperCppPlatform
 
   @override
   Future<void> initialize() => Future.value(null);
+
+  @override
+  Future<bool> toggleRecord() => Future.value(null);
 }
 
 void main() {


### PR DESCRIPTION
This pull request adds the ability to record audio to the macOS and Flutter packages. It includes the addition of a `toggleRecord` method to the Swift and Flutter packages, a `toggleRecord` button in the example lib, and a `temp test` added for testing purposes.

No issues were encountered during development.