### PR TITLE
Add isRecording stream listener to example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,8 +16,12 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  String _platformVersion = 'Unknown';
   final _whisperCppPlugin = WhisperCpp();
+
+  late StreamSubscription<bool> _isRecordingStreamSubscription;
+
+  String _platformVersion = 'Unknown';
+  bool _isRecording = false;
 
   @override
   void initState() {
@@ -52,22 +56,40 @@ class _MyAppState extends State<MyApp> {
           child: Column(
             children: [
               Text('Running on: $_platformVersion\n'),
+              Text('Is Recording: $_isRecording\n'),
               ElevatedButton(
-                onPressed: () async {
-                  await _whisperCppPlugin.initialize();
-                },
+                onPressed: _initialize,
                 child: const Text('Initialize'),
               ),
               ElevatedButton(
                 onPressed: () async {
                   await _whisperCppPlugin.toggleRecord();
                 },
-                child: const Text('Toggle Record'),
+                child: Text(_isRecording ? 'Stop' : 'Start'),
               ),
             ],
           ),
         ),
       ),
     );
+  }
+
+  Future<void> _initialize() async {
+    await _whisperCppPlugin.initialize();
+    _registerIsRecordingChangeListener();
+  }
+
+  void _registerIsRecordingChangeListener() {
+    _isRecordingStreamSubscription =
+        WhisperCpp.isRecording.listen((bool event) {
+      _isRecording = event;
+      setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _isRecordingStreamSubscription.cancel();
+    super.dispose();
   }
 }

--- a/lib/whisper_cpp.dart
+++ b/lib/whisper_cpp.dart
@@ -1,6 +1,10 @@
 import 'whisper_cpp_platform_interface.dart';
 
 class WhisperCpp {
+  static Stream<bool> get isRecording {
+    return WhisperCppPlatform.instance.isRecording;
+  }
+
   Future<String?> getPlatformVersion() {
     return WhisperCppPlatform.instance.getPlatformVersion();
   }

--- a/lib/whisper_cpp_method_channel.dart
+++ b/lib/whisper_cpp_method_channel.dart
@@ -3,11 +3,17 @@ import 'package:flutter/services.dart';
 
 import 'whisper_cpp_platform_interface.dart';
 
+const String _kMethodChannelName = 'plugins.dagemdworku.io/whisper_cpp';
+const String _kIsRecordingEvent = 'whisper_cpp_is_recording_event';
+
 /// An implementation of [WhisperCppPlatform] that uses method channels.
 class MethodChannelWhisperCpp extends WhisperCppPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
-  final methodChannel = const MethodChannel('whisper_cpp');
+  final methodChannel = const MethodChannel(_kMethodChannelName);
+
+  final EventChannel isRecordingEventChannel =
+      const EventChannel('$_kMethodChannelName/token/$_kIsRecordingEvent');
 
   @override
   Future<String?> getPlatformVersion() async {
@@ -24,5 +30,12 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
   @override
   Future<void> toggleRecord() async {
     return await methodChannel.invokeMethod<void>('toggleRecord');
+  }
+
+  @override
+  Stream<bool> get isRecording {
+    return isRecordingEventChannel.receiveBroadcastStream().map((event) {
+      return event is bool ? event : false;
+    });
   }
 }

--- a/lib/whisper_cpp_platform_interface.dart
+++ b/lib/whisper_cpp_platform_interface.dart
@@ -23,6 +23,9 @@ abstract class WhisperCppPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  Stream<bool> get isRecording =>
+      throw UnimplementedError('get isRecording is not implemented');
+
   Future<String?> getPlatformVersion() {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }

--- a/macos/Classes/StreamHandlers/IsRecordingStreamHandler.swift
+++ b/macos/Classes/StreamHandlers/IsRecordingStreamHandler.swift
@@ -1,0 +1,31 @@
+import FlutterMacOS
+
+import Foundation
+import Combine
+
+class IsRecordingStreamHandler: NSObject, FlutterStreamHandler {
+    private var flutterEventSink: FlutterEventSink?
+    private var recordingStateCancellable: AnyCancellable?
+    private let whisperState: WhisperState
+    
+    init(whisperState: WhisperState) {
+        self.whisperState = whisperState
+    }
+    
+    @MainActor
+    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        flutterEventSink = events
+        
+        recordingStateCancellable = whisperState.$isRecording.sink { newValue in
+            self.flutterEventSink?(newValue)
+        }
+        return nil
+    }
+    
+    public func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        flutterEventSink = nil
+        recordingStateCancellable?.cancel()
+        recordingStateCancellable = nil
+        return nil
+    }
+}


### PR DESCRIPTION
This pull request adds a stream listener for the `isRecording` boolean value to the example app. This allows the app to display whether recording is currently active or not. Additionally, it includes changes to the Swift and Flutter packages to support this feature.

No issues are fixed by this pull request.