### PR TITLE
Add whisper transcription log callback implementation

### DIFF
--- a/macos/Classes/WhisperCpp/LibWhisper.swift
+++ b/macos/Classes/WhisperCpp/LibWhisper.swift
@@ -93,14 +93,12 @@ actor WhisperContext {
     
     // Function to get transcription
     // Concatenates all segments of the transcription
-    func getTranscription(updateTranscription: (String) -> Void) -> String {
-        var data = ""
-        transcription = ""
+    func getTranscription() -> String {
+        var transcription = ""
         for i in 0..<whisper_full_n_segments(context) {
-            print("Received value 1: \(String.init(cString: whisper_full_get_segment_text(context, i)))")
-            data += String.init(cString: whisper_full_get_segment_text(context, i))
+            transcription += String.init(cString: whisper_full_get_segment_text(context, i))
         }
-        return data
+        return transcription
     }
     
     // Static function to create a new WhisperContext

--- a/macos/Classes/WhisperCpp/LibWhisper.swift
+++ b/macos/Classes/WhisperCpp/LibWhisper.swift
@@ -43,7 +43,7 @@ actor WhisperContext {
             whisper_reset_timings(context)
             print("About to run whisper_full")
             samples.withUnsafeBufferPointer { samples in
-                if (whisper_full(context, params, samples.baseAddress, Int32(samples.count)) != 0) {
+                if (whisper_full(context, params, samples.baseAddress, Int32(samples.count), logCallback) != 0) {
                     print("Failed to run the model")
                 } else {
                     whisper_print_timings(context)
@@ -75,7 +75,7 @@ actor WhisperContext {
             whisper_reset_timings(context)
             print("About to run whisper_full")
             samples.withUnsafeBufferPointer { samples in
-                if (whisper_full(context, params, samples.baseAddress, Int32(samples.count)) != 0) {
+                if (whisper_full(context, params, samples.baseAddress, Int32(samples.count), logCallback) != 0) {
                     print("Failed to run the model")
                 } else {
                     whisper_print_timings(context)
@@ -84,14 +84,23 @@ actor WhisperContext {
         }
     }
     
+    typealias WhisperTranscriptionLogCallback = @convention(c) (UnsafePointer<CChar>) -> Void
+    
+    let logCallback: whisper_transcription_log_callback = { message in
+        let log = String.init(cString: message!)
+        print("Log from whisper_full: \(log)")
+    }
+    
     // Function to get transcription
     // Concatenates all segments of the transcription
-    func getTranscription() -> String {
-        var transcription = ""
+    func getTranscription(updateTranscription: (String) -> Void) -> String {
+        var data = ""
+        transcription = ""
         for i in 0..<whisper_full_n_segments(context) {
-            transcription += String.init(cString: whisper_full_get_segment_text(context, i))
+            print("Received value 1: \(String.init(cString: whisper_full_get_segment_text(context, i)))")
+            data += String.init(cString: whisper_full_get_segment_text(context, i))
         }
-        return transcription
+        return data
     }
     
     // Static function to create a new WhisperContext

--- a/macos/Classes/WhisperCpp/whisper.cpp/whisper.h
+++ b/macos/Classes/WhisperCpp/whisper.cpp/whisper.h
@@ -446,6 +446,8 @@ extern "C" {
     WHISPER_API struct whisper_full_params * whisper_full_default_params_by_ref(enum whisper_sampling_strategy strategy);
     WHISPER_API struct whisper_full_params whisper_full_default_params(enum whisper_sampling_strategy strategy);
 
+    typedef void (*whisper_transcription_log_callback)(const char *);
+
     // Run the entire model: PCM -> log mel spectrogram -> encoder -> decoder -> text
     // Not thread safe for same context
     // Uses the specified decoding strategy to obtain the text.
@@ -453,14 +455,16 @@ extern "C" {
                 struct whisper_context * ctx,
             struct whisper_full_params   params,
                            const float * samples,
-                                   int   n_samples);
+                                   int   n_samples,
+      whisper_transcription_log_callback log_callback);
 
     WHISPER_API int whisper_full_with_state(
                 struct whisper_context * ctx,
                   struct whisper_state * state,
             struct whisper_full_params   params,
                            const float * samples,
-                                   int   n_samples);
+                                   int   n_samples,
+      whisper_transcription_log_callback log_callback);
 
     // Split the input audio in chunks and process each chunk separately using whisper_full_with_state()
     // Result is stored in the default state of the context
@@ -472,7 +476,8 @@ extern "C" {
             struct whisper_full_params   params,
                            const float * samples,
                                    int   n_samples,
-                                   int   n_processors);
+                                   int   n_processors,
+      whisper_transcription_log_callback log_callback);
 
     // Number of generated text segments
     // A segment can be a few words, a sentence, or even a paragraph.

--- a/test/whisper_cpp_test.dart
+++ b/test/whisper_cpp_test.dart
@@ -15,6 +15,14 @@ class MockWhisperCppPlatform
 
   @override
   Future<bool> toggleRecord() => Future.value(null);
+
+  @override
+  // TODO: implement isRecording
+  Stream<bool> get isRecording => throw UnimplementedError();
+
+  @override
+  // TODO: implement statusLog
+  Stream<String> get statusLog => throw UnimplementedError();
 }
 
 void main() {


### PR DESCRIPTION
This pull request adds a whisper transcription log callback implementation to enable logging of messages from whisper_full. The logCallback function is called from the actor and passed to whisper_full_with_state and whisper_full_parallel. This implementation also includes a temporary fix for a test.

No issues are fixed in this pull request.