### PR TITLE
Add error handling to WhisperCppPlugin initialization

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,11 +78,21 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> _initialize() async {
-    WhisperConfig config = await _whisperCppPlugin.initialize();
-    print(config.toJson());
+    try {
+      WhisperConfig config = await _whisperCppPlugin.initialize();
+      print(config.toJson());
 
-    _registerIsRecordingChangeListener();
-    _registerStatusLogChangeListener();
+      _registerIsRecordingChangeListener();
+      _registerStatusLogChangeListener();
+    } catch (error) {
+      if (error is WhisperCppException) {
+        print('WhisperCppException code: ${error.code}');
+        print('WhisperCppException message: ${error.message}');
+        print('WhisperCppException tips: ${error.tips}');
+      } else {
+        print(error);
+      }
+    }
   }
 
   void _registerIsRecordingChangeListener() {

--- a/lib/src/enums/all.dart
+++ b/lib/src/enums/all.dart
@@ -1,0 +1,1 @@
+export 'whisper_cpp_exception_error_code.dart';

--- a/lib/src/enums/whisper_cpp_exception_error_code.dart
+++ b/lib/src/enums/whisper_cpp_exception_error_code.dart
@@ -1,0 +1,24 @@
+enum WhisperCppExceptionErrorCode {
+  modelNotFound,
+  platformNotSupported,
+  unknown
+}
+
+const Map<WhisperCppExceptionErrorCode, String> errorCodeMap = {
+  WhisperCppExceptionErrorCode.modelNotFound: 'model-not-found',
+  WhisperCppExceptionErrorCode.platformNotSupported: 'platform-not-supported',
+  WhisperCppExceptionErrorCode.unknown: 'unknown',
+};
+
+extension WhisperCppExceptionErrorCodeExtension
+    on WhisperCppExceptionErrorCode {
+  String get value => errorCodeMap[this] ?? 'unknown';
+
+  static WhisperCppExceptionErrorCode fromString(String value) {
+    return errorCodeMap.entries
+        .firstWhere((entry) => entry.value == value,
+            orElse: () =>
+                const MapEntry(WhisperCppExceptionErrorCode.unknown, 'unknown'))
+        .key;
+  }
+}

--- a/lib/src/enums/whisper_cpp_exception_error_code.dart
+++ b/lib/src/enums/whisper_cpp_exception_error_code.dart
@@ -1,6 +1,7 @@
 enum WhisperCppExceptionErrorCode {
   modelNotFound,
   alreadyInitialized,
+  notInitialized,
   platformNotSupported,
   unknown
 }
@@ -8,6 +9,7 @@ enum WhisperCppExceptionErrorCode {
 const Map<WhisperCppExceptionErrorCode, String> errorCodeMap = {
   WhisperCppExceptionErrorCode.modelNotFound: 'model-not-found',
   WhisperCppExceptionErrorCode.alreadyInitialized: 'already-initialized',
+  WhisperCppExceptionErrorCode.notInitialized: 'not-initialized',
   WhisperCppExceptionErrorCode.platformNotSupported: 'platform-not-supported',
   WhisperCppExceptionErrorCode.unknown: 'unknown',
 };

--- a/lib/src/enums/whisper_cpp_exception_error_code.dart
+++ b/lib/src/enums/whisper_cpp_exception_error_code.dart
@@ -1,11 +1,13 @@
 enum WhisperCppExceptionErrorCode {
   modelNotFound,
+  alreadyInitialized,
   platformNotSupported,
   unknown
 }
 
 const Map<WhisperCppExceptionErrorCode, String> errorCodeMap = {
   WhisperCppExceptionErrorCode.modelNotFound: 'model-not-found',
+  WhisperCppExceptionErrorCode.alreadyInitialized: 'already-initialized',
   WhisperCppExceptionErrorCode.platformNotSupported: 'platform-not-supported',
   WhisperCppExceptionErrorCode.unknown: 'unknown',
 };

--- a/lib/src/utils/handlers/error_handler.dart
+++ b/lib/src/utils/handlers/error_handler.dart
@@ -36,6 +36,10 @@ class WhisperCppException implements Exception {
         tips =
             'Please check if the model file exists and is in the correct location';
         break;
+      case WhisperCppExceptionErrorCode.alreadyInitialized:
+        message = 'Already initialized';
+        tips = 'Please check if you have already initialized the plugin';
+        break;
       case WhisperCppExceptionErrorCode.platformNotSupported:
         message = 'Platform not supported';
         tips =

--- a/lib/src/utils/handlers/error_handler.dart
+++ b/lib/src/utils/handlers/error_handler.dart
@@ -1,0 +1,51 @@
+import 'package:whisper_cpp/whisper_cpp.dart';
+
+class WhisperCppException implements Exception {
+  final String code;
+  final String message;
+  final String tips;
+
+  WhisperCppException({
+    required this.code,
+    required this.message,
+    required this.tips,
+  });
+
+  @override
+  String toString() {
+    return 'WhisperCppException: $message (code: $code, tips: $tips)';
+  }
+
+  static WhisperCppException mapToWhisperCppException(String code) {
+    return _getException(
+      WhisperCppExceptionErrorCodeExtension.fromString(code),
+    );
+  }
+
+  static WhisperCppException platformNotSupported() {
+    return _getException(WhisperCppExceptionErrorCode.platformNotSupported);
+  }
+
+  static WhisperCppException _getException(WhisperCppExceptionErrorCode code) {
+    String message;
+    String tips;
+
+    switch (code) {
+      case WhisperCppExceptionErrorCode.modelNotFound:
+        message = 'Model not found';
+        tips =
+            'Please check if the model file exists and is in the correct location';
+        break;
+      case WhisperCppExceptionErrorCode.platformNotSupported:
+        message = 'Platform not supported';
+        tips =
+            'Platform not supported. Currently only macOS and iOS are supported';
+        break;
+      default:
+        message = 'Unknown error occurred';
+        tips = 'Please check your setup';
+    }
+
+    return WhisperCppException(code: code.value, message: message, tips: tips);
+  }
+}

--- a/lib/src/utils/handlers/error_handler.dart
+++ b/lib/src/utils/handlers/error_handler.dart
@@ -40,6 +40,10 @@ class WhisperCppException implements Exception {
         message = 'Already initialized';
         tips = 'Please check if you have already initialized the plugin';
         break;
+      case WhisperCppExceptionErrorCode.notInitialized:
+        message = 'Not initialized';
+        tips = 'Please ensure you have initialized the plugin before using it';
+        break;
       case WhisperCppExceptionErrorCode.platformNotSupported:
         message = 'Platform not supported';
         tips =

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -1,2 +1,3 @@
 export 'handlers/double_handler.dart';
+export 'handlers/error_handler.dart';
 export 'handlers/int_handler.dart';

--- a/lib/whisper_cpp.dart
+++ b/lib/whisper_cpp.dart
@@ -1,7 +1,10 @@
+import 'dart:io';
+
 import 'package:whisper_cpp/whisper_cpp.dart';
 
 import 'whisper_cpp_platform_interface.dart';
 
+export 'src/enums/all.dart';
 export 'src/models/models.dart';
 export 'src/utils/utils.dart';
 
@@ -19,10 +22,16 @@ class WhisperCpp {
   }
 
   Future<WhisperConfig> initialize() {
-    return WhisperCppPlatform.instance.initialize();
+    if (Platform.isMacOS || Platform.isIOS) {
+      return WhisperCppPlatform.instance.initialize();
+    }
+    throw WhisperCppException.platformNotSupported();
   }
 
   Future<void> toggleRecord() {
-    return WhisperCppPlatform.instance.toggleRecord();
+    if (Platform.isMacOS || Platform.isIOS) {
+      return WhisperCppPlatform.instance.toggleRecord();
+    }
+    throw WhisperCppException.platformNotSupported();
   }
 }

--- a/lib/whisper_cpp_method_channel.dart
+++ b/lib/whisper_cpp_method_channel.dart
@@ -39,7 +39,11 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
 
   @override
   Future<void> toggleRecord() async {
-    return await methodChannel.invokeMethod<void>('toggleRecord');
+    try {
+      return await methodChannel.invokeMethod<void>('toggleRecord');
+    } on PlatformException catch (e) {
+      throw WhisperCppException.mapToWhisperCppException(e.code);
+    }
   }
 
   @override

--- a/lib/whisper_cpp_method_channel.dart
+++ b/lib/whisper_cpp_method_channel.dart
@@ -29,10 +29,12 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
 
   @override
   Future<WhisperConfig> initialize() async {
-    final config =
-        await methodChannel.invokeMethod<Map<Object?, Object?>>('initialize');
-
-    return WhisperConfig.fromJson(config);
+    try {
+      final config = await methodChannel.invokeMethod('initialize');
+      return WhisperConfig.fromJson(config);
+    } on PlatformException catch (e) {
+      throw WhisperCppException.mapToWhisperCppException(e.code);
+    }
   }
 
   @override

--- a/macos/Classes/Utilities/ErrorHandler.swift
+++ b/macos/Classes/Utilities/ErrorHandler.swift
@@ -1,0 +1,14 @@
+enum WhisperCppError: String {
+    case modelNotFound = "model-not-found"
+    // TODO: Add the rest of the error enum later
+}
+
+class WhisperCppException: NSError {
+    init(error: WhisperCppError) {
+        super.init(domain: "WhisperCppException", code: 0, userInfo: [NSLocalizedDescriptionKey: error.rawValue])
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+}

--- a/macos/Classes/Utilities/ErrorHandler.swift
+++ b/macos/Classes/Utilities/ErrorHandler.swift
@@ -1,5 +1,6 @@
 enum WhisperCppError: String {
     case modelNotFound = "model-not-found"
+    case alreadyInitialized = "already-initialized"
     // TODO: Add the rest of the error enum later
 }
 

--- a/macos/Classes/Utilities/ErrorHandler.swift
+++ b/macos/Classes/Utilities/ErrorHandler.swift
@@ -1,6 +1,7 @@
 enum WhisperCppError: String {
     case modelNotFound = "model-not-found"
     case alreadyInitialized = "already-initialized"
+    case notInitialized = "not-initialized"
     // TODO: Add the rest of the error enum later
 }
 

--- a/macos/Classes/WhisperCpp/WhisperState.swift
+++ b/macos/Classes/WhisperCpp/WhisperState.swift
@@ -35,14 +35,16 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
     }
     
     // Initialize the WhisperState
-    override init() {
+    init(modelName: String) throws {
         super.init()
+        
         do {
             self.whisperConfig = try loadModel()
             canTranscribe = true
         } catch {
             print(error.localizedDescription)
             messageLog += "\(error.localizedDescription)\n"
+            throw error
         }
     }
     
@@ -58,7 +60,7 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
             return result
         } else {
             messageLog += "Could not locate model\n"
-            return nil
+            throw WhisperCppException(error: .modelNotFound)
         }
     }
     

--- a/macos/Classes/WhisperCppPlugin.swift
+++ b/macos/Classes/WhisperCppPlugin.swift
@@ -36,17 +36,24 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
     }
     
     @MainActor private func initialize(result: @escaping FlutterResult){
-        whisperState = WhisperState()
-        
-        registerIsRecordingEventChannel(whisperState: whisperState!)
-        registerStatusLogEventChannel(whisperState: whisperState!)
-        
-        let whisperConfigDict: [String: Any] = [
-            "modelConfig": whisperState!.whisperConfig!.modelConfig.toDictionary(),
-            "computeConfig": whisperState!.whisperConfig!.computeConfig.toDictionary()
-        ]
-        
-        result(whisperConfigDict)
+        if whisperState == nil {
+            do {
+                whisperState = try WhisperState(modelName: "")
+                
+                registerIsRecordingEventChannel(whisperState: whisperState!)
+                registerStatusLogEventChannel(whisperState: whisperState!)
+                
+                let whisperConfigDict: [String: Any] = [
+                    "modelConfig": whisperState!.whisperConfig!.modelConfig.toDictionary(),
+                    "computeConfig": whisperState!.whisperConfig!.computeConfig.toDictionary()
+                ]
+                
+                result(whisperConfigDict)
+            } catch {
+                result(FlutterError(code: error.localizedDescription,
+                                    message: nil,details: nil))
+            }
+        } 
     }
     
     @MainActor private func toggleRecord(result: @escaping FlutterResult) {

--- a/macos/Classes/WhisperCppPlugin.swift
+++ b/macos/Classes/WhisperCppPlugin.swift
@@ -50,18 +50,16 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
                 
                 result(whisperConfigDict)
             } catch {
-                result(FlutterError(code: error.localizedDescription,
-                                    message: nil,details: nil))
+                result(flutterError(from: error))
             }
         } else {
-            result(FlutterError(code: WhisperCppError.alreadyInitialized.rawValue,
-                                message: nil,details: nil))
+            result(whisperCppError(from: WhisperCppError.alreadyInitialized))
         }
     }
     
     @MainActor private func toggleRecord(result: @escaping FlutterResult) {
         if whisperState == nil {
-            result(nil)
+            result(whisperCppError(from: WhisperCppError.notInitialized))
         } else {
             Task {
                 do {
@@ -84,5 +82,13 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
         let eventChannelName = kFLTWhisperCppMethodChannelName + "/token/" + kFLTWhisperCppStatusLogEvent
         let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
         eventChannel.setStreamHandler(StatusLogStreamHandler(whisperState: whisperState))
+    }
+    
+    private func flutterError(from error: Error) -> FlutterError {
+        return FlutterError(code: "\(error.localizedDescription)", message: nil, details: nil)
+    }
+    
+    private func whisperCppError(from error: WhisperCppError) -> FlutterError {
+        return FlutterError(code: "\(error.rawValue)", message: nil, details: nil)
     }
 }

--- a/macos/Classes/WhisperCppPlugin.swift
+++ b/macos/Classes/WhisperCppPlugin.swift
@@ -53,7 +53,10 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
                 result(FlutterError(code: error.localizedDescription,
                                     message: nil,details: nil))
             }
-        } 
+        } else {
+            result(FlutterError(code: WhisperCppError.alreadyInitialized.rawValue,
+                                message: nil,details: nil))
+        }
     }
     
     @MainActor private func toggleRecord(result: @escaping FlutterResult) {

--- a/test/whisper_cpp_test.dart
+++ b/test/whisper_cpp_test.dart
@@ -11,10 +11,12 @@ class MockWhisperCppPlatform
   Future<String?> getPlatformVersion() => Future.value('42');
 
   @override
-  Future<void> initialize() => Future.value(null);
+  // TODO: implement isRecording
+  Future<WhisperConfig> initialize() => throw UnimplementedError();
 
   @override
-  Future<bool> toggleRecord() => Future.value(null);
+  // TODO: implement isRecording
+  Future<bool> toggleRecord() => throw UnimplementedError();
 
   @override
   // TODO: implement isRecording


### PR DESCRIPTION
This PR adds error handling to the initialization process of the WhisperCppPlugin. It introduces a new WhisperCppError enum and a WhisperCppException class to handle errors. The platform is checked before initializing and if it's not supported, a platformNotSupported exception is thrown. If the model file is not found, a modelNotFound exception is thrown. If the plugin is already initialized, an alreadyInitialized exception is thrown. If the plugin is not initialized, a notInitialized exception is thrown. Additionally, the MockWhisperCppPlatform is updated to implement the isRecording method.

No issue reference.