### PR TITLE
Add modelName parameter to WhisperCpp initialization

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'package:flutter/material.dart';
 import 'dart:async';
 
@@ -79,19 +81,18 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> _initialize() async {
     try {
-      WhisperConfig config = await _whisperCppPlugin.initialize();
+      WhisperConfig config = await _whisperCppPlugin.initialize(
+        modelName: 'ggml-tiny.en',
+      );
       print(config.toJson());
 
       _registerIsRecordingChangeListener();
       _registerStatusLogChangeListener();
-    } catch (error) {
-      if (error is WhisperCppException) {
-        print('WhisperCppException code: ${error.code}');
-        print('WhisperCppException message: ${error.message}');
-        print('WhisperCppException tips: ${error.tips}');
-      } else {
-        print(error);
-      }
+    } on WhisperCppException catch (e) {
+      print('WhisperCppException code: ${e.code}');
+      print('WhisperCppException message: ${e.message}');
+      print('WhisperCppException tips: ${e.tips}');
+      print(e.toString());
     }
   }
 

--- a/lib/src/enums/whisper_cpp_exception_error_code.dart
+++ b/lib/src/enums/whisper_cpp_exception_error_code.dart
@@ -3,6 +3,7 @@ enum WhisperCppExceptionErrorCode {
   alreadyInitialized,
   notInitialized,
   platformNotSupported,
+  configurationError,
   unknown
 }
 
@@ -11,6 +12,7 @@ const Map<WhisperCppExceptionErrorCode, String> errorCodeMap = {
   WhisperCppExceptionErrorCode.alreadyInitialized: 'already-initialized',
   WhisperCppExceptionErrorCode.notInitialized: 'not-initialized',
   WhisperCppExceptionErrorCode.platformNotSupported: 'platform-not-supported',
+  WhisperCppExceptionErrorCode.configurationError: 'configuration-error',
   WhisperCppExceptionErrorCode.unknown: 'unknown',
 };
 

--- a/lib/src/utils/handlers/error_handler.dart
+++ b/lib/src/utils/handlers/error_handler.dart
@@ -44,6 +44,10 @@ class WhisperCppException implements Exception {
         message = 'Not initialized';
         tips = 'Please ensure you have initialized the plugin before using it';
         break;
+      case WhisperCppExceptionErrorCode.configurationError:
+        message = 'Configuration error';
+        tips = 'Please check your configuration';
+        break;
       case WhisperCppExceptionErrorCode.platformNotSupported:
         message = 'Platform not supported';
         tips =

--- a/lib/whisper_cpp.dart
+++ b/lib/whisper_cpp.dart
@@ -21,9 +21,11 @@ class WhisperCpp {
     return WhisperCppPlatform.instance.getPlatformVersion();
   }
 
-  Future<WhisperConfig> initialize() {
+  Future<WhisperConfig> initialize({
+    String modelName = 'ggml-tiny.en',
+  }) {
     if (Platform.isMacOS || Platform.isIOS) {
-      return WhisperCppPlatform.instance.initialize();
+      return WhisperCppPlatform.instance.initialize(modelName: modelName);
     }
     throw WhisperCppException.platformNotSupported();
   }

--- a/lib/whisper_cpp_method_channel.dart
+++ b/lib/whisper_cpp_method_channel.dart
@@ -28,9 +28,15 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
   }
 
   @override
-  Future<WhisperConfig> initialize() async {
+  Future<WhisperConfig> initialize({
+    required String modelName,
+  }) async {
+    Map<String, dynamic> arguments = {
+      'modelName': modelName,
+    };
+
     try {
-      final config = await methodChannel.invokeMethod('initialize');
+      final config = await methodChannel.invokeMethod('initialize', arguments);
       return WhisperConfig.fromJson(config);
     } on PlatformException catch (e) {
       throw WhisperCppException.mapToWhisperCppException(e.code);

--- a/lib/whisper_cpp_platform_interface.dart
+++ b/lib/whisper_cpp_platform_interface.dart
@@ -34,7 +34,9 @@ abstract class WhisperCppPlatform extends PlatformInterface {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
-  Future<WhisperConfig> initialize() {
+  Future<WhisperConfig> initialize({
+    required String modelName,
+  }) {
     throw UnimplementedError('initialize() has not been implemented.');
   }
 

--- a/macos/Classes/Utilities/ErrorHandler.swift
+++ b/macos/Classes/Utilities/ErrorHandler.swift
@@ -2,6 +2,7 @@ enum WhisperCppError: String {
     case modelNotFound = "model-not-found"
     case alreadyInitialized = "already-initialized"
     case notInitialized = "not-initialized"
+    case configurationError = "configuration-error"
     // TODO: Add the rest of the error enum later
 }
 

--- a/macos/Classes/WhisperCpp/WhisperState.swift
+++ b/macos/Classes/WhisperCpp/WhisperState.swift
@@ -19,11 +19,6 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
     private var recordedFile: URL? = nil  // The URL of the recorded audio file
     private var audioPlayer: AVAudioPlayer?  // The audio player for playback of recorded audio
     
-    // The URL of the model file
-    private var modelUrl: URL? {
-        Bundle.main.url(forResource: "ggml-tiny.en", withExtension: "bin", subdirectory: nil)
-    }
-    
     // The URL of the sample audio file
     private var sampleUrl: URL? {
         Bundle.main.url(forResource: "jfk", withExtension: "wav", subdirectory: nil)
@@ -39,7 +34,7 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
         super.init()
         
         do {
-            self.whisperConfig = try loadModel()
+            self.whisperConfig = try loadModel(modelName: modelName)
             canTranscribe = true
         } catch {
             print(error.localizedDescription)
@@ -49,9 +44,14 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
     }
     
     // Load the Whisper model
-    private func loadModel() throws -> WhisperConfig? {
+    private func loadModel(modelName: String) throws -> WhisperConfig? {
         messageLog += "Loading model...\n"
         statusLog = "Loading model..."
+        
+        var modelUrl: URL? {
+            Bundle.main.url(forResource: modelName, withExtension: "bin", subdirectory: nil)
+        }
+        
         if let modelUrl {
             let result: WhisperConfig = try WhisperContext.createContext(path: modelUrl.path())
             whisperContext = result.whisperContext

--- a/macos/Classes/WhisperCppPlugin.swift
+++ b/macos/Classes/WhisperCppPlugin.swift
@@ -27,7 +27,7 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
         case "getPlatformVersion":
             result("macOS " + ProcessInfo.processInfo.operatingSystemVersionString)
         case "initialize":
-            initialize(result: result)
+            initialize(call: call, result: result)
         case "toggleRecord":
             toggleRecord(result: result)
         default:
@@ -35,10 +35,19 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    @MainActor private func initialize(result: @escaping FlutterResult){
+    @MainActor private func initialize(call: FlutterMethodCall, result: @escaping FlutterResult){
+        guard let arguments = call.arguments as? [String: Any] else {
+            result(whisperCppError(from: WhisperCppError.configurationError))
+            return
+        }
+        guard let modelName = arguments["modelName"] as? String else {
+            result(whisperCppError(from: WhisperCppError.configurationError))
+            return
+        }
+
         if whisperState == nil {
             do {
-                whisperState = try WhisperState(modelName: "")
+                whisperState = try WhisperState(modelName: modelName)
                 
                 registerIsRecordingEventChannel(whisperState: whisperState!)
                 registerStatusLogEventChannel(whisperState: whisperState!)
@@ -85,10 +94,10 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
     }
     
     private func flutterError(from error: Error) -> FlutterError {
-        return FlutterError(code: "\(error.localizedDescription)", message: nil, details: nil)
+        return FlutterError(code: error.localizedDescription, message: nil, details: nil)
     }
     
     private func whisperCppError(from error: WhisperCppError) -> FlutterError {
-        return FlutterError(code: "\(error.rawValue)", message: nil, details: nil)
+        return FlutterError(code: error.rawValue, message: nil, details: nil)
     }
 }


### PR DESCRIPTION
This pull request adds a new parameter, `modelName`, to the `initialize()` method of the `WhisperCpp` class. This parameter allows the user to specify the name of the model file to be loaded. Additionally, the `loadModel()` method of the `WhisperState` class has been updated to accept the `modelName` parameter and use it to load the model file. Finally, the `initialize()` method of the `MethodChannelWhisperCpp` class has been updated to accept the `modelName` parameter and pass it to the platform channel method. This change improves the flexibility of the `WhisperCpp` plugin by allowing users to load different model files as needed.