### PR TITLE
Add WhisperResult and WhisperTokenData models and result event channel

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,11 +21,13 @@ class _MyAppState extends State<MyApp> {
   final _whisperCppPlugin = WhisperCpp();
 
   late StreamSubscription<bool> _isRecordingStreamSubscription;
+  late StreamSubscription<WhisperResult?> _resultStreamSubscription;
   late StreamSubscription<dynamic> _statusLogStreamSubscription;
 
   String _platformVersion = 'Unknown';
   bool _isRecording = false;
   String _statusLog = '';
+  String _result = '';
 
   @override
   void initState() {
@@ -72,6 +74,8 @@ class _MyAppState extends State<MyApp> {
                 },
                 child: Text(_isRecording ? 'Stop' : 'Start'),
               ),
+              const Divider(),
+              Text('Result: $_result\n'),
             ],
           ),
         ),
@@ -88,6 +92,7 @@ class _MyAppState extends State<MyApp> {
 
       _registerIsRecordingChangeListener();
       _registerStatusLogChangeListener();
+      _registerResultChangeListener();
     } on WhisperCppException catch (e) {
       print('WhisperCppException code: ${e.code}');
       print('WhisperCppException message: ${e.message}');
@@ -111,10 +116,21 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
+  void _registerResultChangeListener() {
+    _resultStreamSubscription = WhisperCpp.result.listen((
+      WhisperResult? event,
+    ) {
+      print(event?.toJson() ?? '');
+      _result += event?.text ?? '';
+      setState(() {});
+    });
+  }
+
   @override
   void dispose() {
     _isRecordingStreamSubscription.cancel();
     _statusLogStreamSubscription.cancel();
+    _resultStreamSubscription.cancel();
     super.dispose();
   }
 }

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -1,3 +1,6 @@
 export 'whisper_config/whisper_config.dart';
 export 'whisper_config/whisper_compute_config.dart';
 export 'whisper_config/whisper_model_config.dart';
+
+export 'whisper_result/whisper_result.dart';
+export 'whisper_result/whisper_token_data.dart';

--- a/lib/src/models/whisper_result/whisper_result.dart
+++ b/lib/src/models/whisper_result/whisper_result.dart
@@ -1,0 +1,31 @@
+import 'package:whisper_cpp/whisper_cpp.dart';
+
+class WhisperResult {
+  final int time;
+  final String text;
+  final WhisperTokenData tokenData;
+
+  WhisperResult({
+    required this.time,
+    required this.text,
+    required this.tokenData,
+  });
+
+  factory WhisperResult.fromJson(Map<Object?, Object?>? data) {
+    Map<String, dynamic> json = Map<String, dynamic>.from(data as Map);
+
+    return WhisperResult(
+      time: IntHandler.parse(json['time']),
+      text: json['text'],
+      tokenData: WhisperTokenData.fromJson(json['tokenData']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'time': time,
+      'text': text,
+      'tokenData': tokenData.toJson(),
+    };
+  }
+}

--- a/lib/src/models/whisper_result/whisper_token_data.dart
+++ b/lib/src/models/whisper_result/whisper_token_data.dart
@@ -1,0 +1,55 @@
+import 'package:whisper_cpp/whisper_cpp.dart';
+
+class WhisperTokenData {
+  final int id;
+  final int tid;
+  final double p;
+  final double plog;
+  final double pt;
+  final double ptsum;
+  final int t0;
+  final int t1;
+  final double vlen;
+
+  WhisperTokenData({
+    required this.id,
+    required this.tid,
+    required this.p,
+    required this.plog,
+    required this.pt,
+    required this.ptsum,
+    required this.t0,
+    required this.t1,
+    required this.vlen,
+  });
+
+  factory WhisperTokenData.fromJson(Map<Object?, Object?>? data) {
+    Map<String, dynamic> json = Map<String, dynamic>.from(data as Map);
+
+    return WhisperTokenData(
+      id: IntHandler.parse(json['id']),
+      tid: IntHandler.parse(json['tid']),
+      p: DoubleHandler.parse(json['p']),
+      plog: DoubleHandler.parse(json['plog']),
+      pt: DoubleHandler.parse(json['pt']),
+      ptsum: DoubleHandler.parse(json['ptsum']),
+      t0: IntHandler.parse(json['t0']),
+      t1: IntHandler.parse(json['t1']),
+      vlen: DoubleHandler.parse(json['vlen']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'tid': tid,
+      'p': p,
+      'plog': plog,
+      'pt': pt,
+      'ptsum': ptsum,
+      't0': t0,
+      't1': t1,
+      'vlen': vlen,
+    };
+  }
+}

--- a/lib/whisper_cpp.dart
+++ b/lib/whisper_cpp.dart
@@ -17,6 +17,10 @@ class WhisperCpp {
     return WhisperCppPlatform.instance.statusLog;
   }
 
+  static Stream<WhisperResult?> get result {
+    return WhisperCppPlatform.instance.result;
+  }
+
   Future<String?> getPlatformVersion() {
     return WhisperCppPlatform.instance.getPlatformVersion();
   }

--- a/lib/whisper_cpp_method_channel.dart
+++ b/lib/whisper_cpp_method_channel.dart
@@ -7,6 +7,7 @@ import 'whisper_cpp_platform_interface.dart';
 const String _kMethodChannelName = 'plugins.dagemdworku.io/whisper_cpp';
 const String _kIsRecordingEvent = 'whisper_cpp_is_recording_event';
 const String _kStatusLogEvent = 'whisper_cpp_status_log_event';
+const String _kResultEvent = 'whisper_cpp_result_event';
 
 /// An implementation of [WhisperCppPlatform] that uses method channels.
 class MethodChannelWhisperCpp extends WhisperCppPlatform {
@@ -19,6 +20,9 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
 
   final EventChannel statusLogEventChannel =
       const EventChannel('$_kMethodChannelName/token/$_kStatusLogEvent');
+
+  final EventChannel resultEventChannel =
+      const EventChannel('$_kMethodChannelName/token/$_kResultEvent');
 
   @override
   Future<String?> getPlatformVersion() async {
@@ -63,6 +67,14 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
   Stream<String> get statusLog {
     return statusLogEventChannel.receiveBroadcastStream().map((event) {
       return event is String ? event : '';
+    });
+  }
+
+  @override
+  Stream<WhisperResult?> get result {
+    return resultEventChannel.receiveBroadcastStream().map((event) {
+      print(event);
+      return event is Map ? WhisperResult.fromJson(event) : null;
     });
   }
 }

--- a/lib/whisper_cpp_platform_interface.dart
+++ b/lib/whisper_cpp_platform_interface.dart
@@ -25,10 +25,13 @@ abstract class WhisperCppPlatform extends PlatformInterface {
   }
 
   Stream<bool> get isRecording =>
-      throw UnimplementedError('get isRecording is not implemented');
+      throw UnimplementedError('get isRecording stream is not implemented');
 
   Stream<String> get statusLog =>
-      throw UnimplementedError('get statusLogStream is not implemented');
+      throw UnimplementedError('get statusLog stream is not implemented');
+
+  Stream<WhisperResult?> get result =>
+      throw UnimplementedError('get result stream is not implemented');
 
   Future<String?> getPlatformVersion() {
     throw UnimplementedError('platformVersion() has not been implemented.');

--- a/macos/Classes/Models/WhisperResult.swift
+++ b/macos/Classes/Models/WhisperResult.swift
@@ -1,0 +1,19 @@
+struct WhisperResult {
+    var time: Int64
+    var text: String
+    var tokenData: WhisperTokenData
+
+    init(result: whisper_result) {
+        self.time = result.time
+        self.text = String.init(cString: result.text)
+        self.tokenData = WhisperTokenData(token_data: result.token_data)
+    }
+
+    func toDictionary() -> [String: Any] {
+        return [
+            "time": self.time,
+            "text": self.text,
+            "tokenData": self.tokenData.toDictionary()
+        ]
+    }
+}

--- a/macos/Classes/Models/WhisperTokenData.swift
+++ b/macos/Classes/Models/WhisperTokenData.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+struct WhisperTokenData {
+    var id: Int32
+    var tid: Int32
+    var p: Float
+    var plog: Float
+    var pt: Float
+    var ptsum: Float
+    var t0: Int64
+    var t1: Int64
+    var vlen: Float
+
+    init(token_data: whisper_token_data) {
+        self.id = token_data.id
+        self.tid = token_data.tid
+        self.p = token_data.p
+        self.plog = token_data.plog
+        self.pt = token_data.pt
+        self.ptsum = token_data.ptsum
+        self.t0 = token_data.t0
+        self.t1 = token_data.t1
+        self.vlen = token_data.vlen
+    }
+
+    func toDictionary() -> [String: Any] {
+        return [
+            "id": self.id,
+            "tid": self.tid,
+            "p": self.p,
+            "plog": self.plog,
+            "pt": self.pt,
+            "ptsum": self.ptsum,
+            "t0": self.t0,
+            "t1": self.t1,
+            "vlen": self.vlen
+        ]
+    }
+}

--- a/macos/Classes/StreamHandlers/ResultStreamHandler.swift
+++ b/macos/Classes/StreamHandlers/ResultStreamHandler.swift
@@ -1,0 +1,31 @@
+import FlutterMacOS
+
+import Foundation
+import Combine
+
+class ResultStreamHandler: NSObject, FlutterStreamHandler {
+    private var flutterEventSink: FlutterEventSink?
+    private var resultStateCancellable: AnyCancellable?
+    private let whisperState: WhisperState
+    
+    init(whisperState: WhisperState) {
+        self.whisperState = whisperState
+    }
+    
+    @MainActor
+    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        flutterEventSink = events
+        
+        resultStateCancellable = whisperState.$result.sink { newValue in
+            self.flutterEventSink?(newValue?.toDictionary())
+        }
+        return nil
+    }
+    
+    public func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        flutterEventSink = nil
+        resultStateCancellable?.cancel()
+        resultStateCancellable = nil
+        return nil
+    }
+}

--- a/macos/Classes/WhisperCpp/WhisperState.swift
+++ b/macos/Classes/WhisperCpp/WhisperState.swift
@@ -11,6 +11,9 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
     @Published var isRecording = false  // Indicates if the app is currently recording audio
     @Published var messageLog = ""  // Log of messages for debugging and user feedback
     @Published var statusLog = ""  // Log of messages for debugging and user feedback
+
+    @Published var result: WhisperResult?
+    
     
     var whisperConfig: WhisperConfig?
     
@@ -89,7 +92,8 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
             let data = try readAudioSamples(url)
             messageLog += "Transcribing data...\n"
             statusLog = "Transcribing data..."
-            await whisperContext.fullTranscribe(samples: data)
+            
+            await whisperContext.fullTranscribe(samples: data, state: self)
             let text = await whisperContext.getTranscription()
             messageLog += "Done: \(text)\n"
             statusLog = "Done."
@@ -100,11 +104,15 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
         
         canTranscribe = true
     }
+
+    func updateResult(with newValue: whisper_result) {
+        self.result = WhisperResult(result: newValue)
+    }
     
     // Read audio samples from a file
     private func readAudioSamples(_ url: URL) throws -> [Float] {
         stopPlayback()
-        try startPlayback(url)
+        // try startPlayback(url)
         return try RiffWaveUtils.decodeWaveFile(url)
     }
     

--- a/macos/Classes/WhisperCpp/whisper.cpp/whisper.cpp
+++ b/macos/Classes/WhisperCpp/whisper.cpp/whisper.cpp
@@ -3175,21 +3175,21 @@ struct whisper_config * _whisper_init(whisper_context * ctx, whisper_config* res
 }
 
 struct whisper_config * whisper_init_from_file(const char * path_model) {
-    whisper_config* result = new whisper_config;
-    whisper_context * ctx = whisper_init_from_file_no_state(path_model, &result->model_config);
-    return _whisper_init(ctx, result);
+    whisper_config* config = new whisper_config;
+    whisper_context * ctx = whisper_init_from_file_no_state(path_model, &config->model_config);
+    return _whisper_init(ctx, config);
 }
 
 struct whisper_config * whisper_init_from_buffer(void * buffer, size_t buffer_size) {
-    whisper_config* result = new whisper_config;
-    whisper_context * ctx = whisper_init_from_buffer_no_state(buffer, buffer_size, &result->model_config);
-    return _whisper_init(ctx, result);
+    whisper_config* config = new whisper_config;
+    whisper_context * ctx = whisper_init_from_buffer_no_state(buffer, buffer_size, &config->model_config);
+    return _whisper_init(ctx, config);
 }
 
 struct whisper_config * whisper_init(struct whisper_model_loader * loader) {
-    whisper_config* result = new whisper_config;
-    whisper_context * ctx = whisper_init_no_state(loader, &result->model_config);
-    return _whisper_init(ctx, result);
+    whisper_config* config = new whisper_config;
+    whisper_context * ctx = whisper_init_no_state(loader, &config->model_config);
+    return _whisper_init(ctx, config);
 }
 
 void whisper_free_state(struct whisper_state * state)
@@ -5058,6 +5058,13 @@ int whisper_full_with_state(
                     if (params.tdrz_enable && tokens_cur[i].id == whisper_token_solm(ctx)) {
                         speaker_turn_next = true;
                     }
+                    
+                    whisper_result* result = new whisper_result;
+                    result->time = seek + 2*(tokens_cur[i].tid - whisper_token_beg(ctx));
+                    result->text = ctx->vocab.id_to_token[tokens_cur[i].id].c_str();
+                    result->token_data = tokens_cur[i];
+                    
+                    log_callback(result);
 
                     if (tokens_cur[i].id > whisper_token_beg(ctx) && !params.single_segment) {
                         const auto t1 = seek + 2*(tokens_cur[i].tid - whisper_token_beg(ctx));
@@ -5069,7 +5076,6 @@ int whisper_full_with_state(
                             if (params.print_realtime) {
                                 if (params.print_timestamps) {
                                     printf("[%s --> %s]  %s\n", to_timestamp(tt0).c_str(), to_timestamp(tt1).c_str(), text.c_str());
-                                    log_callback(text.c_str());
                                 } else {
                                     printf("%s", text.c_str());
                                     fflush(stdout);

--- a/macos/Classes/WhisperCpp/whisper.cpp/whisper.h
+++ b/macos/Classes/WhisperCpp/whisper.cpp/whisper.h
@@ -122,6 +122,12 @@ extern "C" {
         whisper_compute_config compute_config;
     } whisper_config;
 
+    typedef struct whisper_result {
+        int64_t time;
+        const char * text;
+        whisper_token_data token_data;
+    } whisper_result;
+
     typedef struct whisper_model_loader {
         void * context;
 
@@ -480,7 +486,7 @@ extern "C" {
     WHISPER_API struct whisper_full_params * whisper_full_default_params_by_ref(enum whisper_sampling_strategy strategy);
     WHISPER_API struct whisper_full_params whisper_full_default_params(enum whisper_sampling_strategy strategy);
 
-    typedef void (*whisper_transcription_log_callback)(const char *);
+    typedef void (*whisper_transcription_log_callback)(whisper_result *);
 
     // Run the entire model: PCM -> log mel spectrogram -> encoder -> decoder -> text
     // Not thread safe for same context

--- a/macos/Classes/WhisperCppPlugin.swift
+++ b/macos/Classes/WhisperCppPlugin.swift
@@ -4,6 +4,7 @@ import FlutterMacOS
 let kFLTWhisperCppMethodChannelName = "plugins.dagemdworku.io/whisper_cpp"
 let kFLTWhisperCppIsRecordingEvent = "whisper_cpp_is_recording_event"
 let kFLTWhisperCppStatusLogEvent = "whisper_cpp_status_log_event"
+let kFLTWhisperCppResultEvent = "whisper_cpp_result_event"
 
 public class WhisperCppPlugin: NSObject, FlutterPlugin {
     private var whisperState: WhisperState?
@@ -51,6 +52,7 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
                 
                 registerIsRecordingEventChannel(whisperState: whisperState!)
                 registerStatusLogEventChannel(whisperState: whisperState!)
+                registerResultEventChannel(whisperState: whisperState!)
                 
                 let whisperConfigDict: [String: Any] = [
                     "modelConfig": whisperState!.whisperConfig!.modelConfig.toDictionary(),
@@ -91,6 +93,12 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
         let eventChannelName = kFLTWhisperCppMethodChannelName + "/token/" + kFLTWhisperCppStatusLogEvent
         let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
         eventChannel.setStreamHandler(StatusLogStreamHandler(whisperState: whisperState))
+    }
+
+    private func registerResultEventChannel(whisperState: WhisperState) {
+        let eventChannelName = kFLTWhisperCppMethodChannelName + "/token/" + kFLTWhisperCppResultEvent
+        let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
+        eventChannel.setStreamHandler(ResultStreamHandler(whisperState: whisperState))
     }
     
     private func flutterError(from error: Error) -> FlutterError {

--- a/test/whisper_cpp_test.dart
+++ b/test/whisper_cpp_test.dart
@@ -12,7 +12,8 @@ class MockWhisperCppPlatform
 
   @override
   // TODO: implement isRecording
-  Future<WhisperConfig> initialize() => throw UnimplementedError();
+  Future<WhisperConfig> initialize({required String modelName}) =>
+      throw UnimplementedError();
 
   @override
   // TODO: implement isRecording
@@ -25,6 +26,10 @@ class MockWhisperCppPlatform
   @override
   // TODO: implement statusLog
   Stream<String> get statusLog => throw UnimplementedError();
+
+  @override
+  // TODO: implement result
+  Stream<WhisperResult?> get result => throw UnimplementedError();
 }
 
 void main() {


### PR DESCRIPTION
This pull request adds the `WhisperResult` and `WhisperTokenData` models to the codebase, along with the necessary changes to the `WhisperCpp` and `MethodChannelWhisperCpp` classes to support the new `result` event channel. The `ResultStreamHandler` class is also included to handle the stream of recognition results and update the UI accordingly. This PR does not include any changes to commits or files, but rather adds new functionality to the codebase.