### PR TITLE
Add WhisperSummary model and performance metrics

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,8 +21,9 @@ class _MyAppState extends State<MyApp> {
   final _whisperCppPlugin = WhisperCpp();
 
   late StreamSubscription<bool> _isRecordingStreamSubscription;
-  late StreamSubscription<WhisperResult?> _resultStreamSubscription;
   late StreamSubscription<dynamic> _statusLogStreamSubscription;
+  late StreamSubscription<WhisperResult?> _resultStreamSubscription;
+  late StreamSubscription<WhisperSummary?> _summaryStreamSubscription;
 
   String _platformVersion = 'Unknown';
   bool _isRecording = false;
@@ -93,6 +94,7 @@ class _MyAppState extends State<MyApp> {
       _registerIsRecordingChangeListener();
       _registerStatusLogChangeListener();
       _registerResultChangeListener();
+      _registerSummaryChangeListener();
     } on WhisperCppException catch (e) {
       print('WhisperCppException code: ${e.code}');
       print('WhisperCppException message: ${e.message}');
@@ -120,9 +122,19 @@ class _MyAppState extends State<MyApp> {
     _resultStreamSubscription = WhisperCpp.result.listen((
       WhisperResult? event,
     ) {
-      print(event?.toJson() ?? '');
+      // print(event?.toJson() ?? '');
       _result += event?.text ?? '';
       setState(() {});
+    });
+  }
+
+  void _registerSummaryChangeListener() {
+    _summaryStreamSubscription = WhisperCpp.summary.listen((
+      WhisperSummary? event,
+    ) {
+      print(event?.toJson() ?? '');
+      print('load time: ${event?.loadTime}');
+      
     });
   }
 
@@ -131,6 +143,7 @@ class _MyAppState extends State<MyApp> {
     _isRecordingStreamSubscription.cancel();
     _statusLogStreamSubscription.cancel();
     _resultStreamSubscription.cancel();
+    _summaryStreamSubscription.cancel();
     super.dispose();
   }
 }

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -4,3 +4,5 @@ export 'whisper_config/whisper_model_config.dart';
 
 export 'whisper_result/whisper_result.dart';
 export 'whisper_result/whisper_token_data.dart';
+
+export 'whisper_summary/whisper_summary.dart';

--- a/lib/src/models/whisper_summary/whisper_summary.dart
+++ b/lib/src/models/whisper_summary/whisper_summary.dart
@@ -1,0 +1,85 @@
+import 'package:whisper_cpp/whisper_cpp.dart';
+
+class WhisperSummary {
+  int tSampleUs;
+  int nSample;
+  int tEncodeUs;
+  int nEncode;
+  int tDecodeUs;
+  int nDecode;
+  int tPromptUs;
+  int nPrompt;
+  int tStartUs;
+  int tEndUs;
+  int nFailP;
+  int nFailH;
+  int tLoadUs;
+  int tMelUs;
+
+  WhisperSummary({
+    required this.tSampleUs,
+    required this.nSample,
+    required this.tEncodeUs,
+    required this.nEncode,
+    required this.tDecodeUs,
+    required this.nDecode,
+    required this.tPromptUs,
+    required this.nPrompt,
+    required this.tStartUs,
+    required this.tEndUs,
+    required this.nFailP,
+    required this.nFailH,
+    required this.tLoadUs,
+    required this.tMelUs,
+  });
+
+  double get sampleTimePerRun => tSampleUs / 1000.0 / nSample;
+  double get encodeTimePerRun => tEncodeUs / 1000.0 / nEncode;
+  double get decodeTimePerRun => tDecodeUs / 1000.0 / nDecode;
+  double get promptTimePerRun => tPromptUs / 1000.0 / nPrompt;
+  double get totalTime => (tEndUs - tStartUs) / 1000.0;
+
+  double get loadTime => tLoadUs / 1000.0;
+  String get fallbacks => '$nFailP p / $nFailH h';
+  double get melTime => tMelUs / 1000.0;
+
+  factory WhisperSummary.fromJson(Map<Object?, Object?>? data) {
+    Map<String, dynamic> json = Map<String, dynamic>.from(data as Map);
+
+    return WhisperSummary(
+      tSampleUs: IntHandler.parse(json['tSampleUs']),
+      nSample: IntHandler.parse(json['nSample']),
+      tEncodeUs: IntHandler.parse(json['tEncodeUs']),
+      nEncode: IntHandler.parse(json['nEncode']),
+      tDecodeUs: IntHandler.parse(json['tDecodeUs']),
+      nDecode: IntHandler.parse(json['nDecode']),
+      tPromptUs: IntHandler.parse(json['tPromptUs']),
+      nPrompt: IntHandler.parse(json['nPrompt']),
+      tStartUs: IntHandler.parse(json['tStartUs']),
+      tEndUs: IntHandler.parse(json['tEndUs']),
+      nFailP: IntHandler.parse(json['nFailP']),
+      nFailH: IntHandler.parse(json['nFailH']),
+      tLoadUs: IntHandler.parse(json['tLoadUs']),
+      tMelUs: IntHandler.parse(json['tMelUs']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'tSampleUs': tSampleUs,
+      'nSample': nSample,
+      'tEncodeUs': tEncodeUs,
+      'nEncode': nEncode,
+      'tDecodeUs': tDecodeUs,
+      'nDecode': nDecode,
+      'tPromptUs': tPromptUs,
+      'nPrompt': nPrompt,
+      'tStartUs': tStartUs,
+      'tEndUs': tEndUs,
+      'nFailP': nFailP,
+      'nFailH': nFailH,
+      'tLoadUs': tLoadUs,
+      'tMelUs': tMelUs,
+    };
+  }
+}

--- a/lib/whisper_cpp.dart
+++ b/lib/whisper_cpp.dart
@@ -21,6 +21,10 @@ class WhisperCpp {
     return WhisperCppPlatform.instance.result;
   }
 
+  static Stream<WhisperSummary?> get summary {
+    return WhisperCppPlatform.instance.summary;
+  }
+
   Future<String?> getPlatformVersion() {
     return WhisperCppPlatform.instance.getPlatformVersion();
   }

--- a/lib/whisper_cpp_method_channel.dart
+++ b/lib/whisper_cpp_method_channel.dart
@@ -8,6 +8,7 @@ const String _kMethodChannelName = 'plugins.dagemdworku.io/whisper_cpp';
 const String _kIsRecordingEvent = 'whisper_cpp_is_recording_event';
 const String _kStatusLogEvent = 'whisper_cpp_status_log_event';
 const String _kResultEvent = 'whisper_cpp_result_event';
+const String _kSummaryEvent = 'whisper_cpp_summary_event';
 
 /// An implementation of [WhisperCppPlatform] that uses method channels.
 class MethodChannelWhisperCpp extends WhisperCppPlatform {
@@ -23,6 +24,9 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
 
   final EventChannel resultEventChannel =
       const EventChannel('$_kMethodChannelName/token/$_kResultEvent');
+
+  final EventChannel summaryEventChannel =
+      const EventChannel('$_kMethodChannelName/token/$_kSummaryEvent');
 
   @override
   Future<String?> getPlatformVersion() async {
@@ -73,8 +77,15 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
   @override
   Stream<WhisperResult?> get result {
     return resultEventChannel.receiveBroadcastStream().map((event) {
-      print(event);
       return event is Map ? WhisperResult.fromJson(event) : null;
+    });
+  }
+
+  @override
+  Stream<WhisperSummary?> get summary {
+    return summaryEventChannel.receiveBroadcastStream().map((event) {
+      print(event);
+      return event is Map ? WhisperSummary.fromJson(event) : null;
     });
   }
 }

--- a/lib/whisper_cpp_platform_interface.dart
+++ b/lib/whisper_cpp_platform_interface.dart
@@ -32,6 +32,9 @@ abstract class WhisperCppPlatform extends PlatformInterface {
 
   Stream<WhisperResult?> get result =>
       throw UnimplementedError('get result stream is not implemented');
+      
+  Stream<WhisperSummary?> get summary =>
+      throw UnimplementedError('get summary stream is not implemented');
 
   Future<String?> getPlatformVersion() {
     throw UnimplementedError('platformVersion() has not been implemented.');

--- a/macos/Classes/Models/WhisperSummary.swift
+++ b/macos/Classes/Models/WhisperSummary.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+struct WhisperSummary {
+    var tSampleUs: Int64
+    var nSample: Int32
+    var tEncodeUs: Int64
+    var nEncode: Int32
+    var tDecodeUs: Int64
+    var nDecode: Int32
+    var tPromptUs: Int64
+    var nPrompt: Int32
+    var tStartUs: Int64
+    var tEndUs: Int64
+    var nFailP: Int32
+    var nFailH: Int32
+    var tLoadUs: Int64
+    var tMelUs: Int64
+    
+    init(summary: whisper_summary) {
+        self.tSampleUs = summary.t_sample_us
+        self.nSample = summary.n_sample
+        self.tEncodeUs = summary.t_encode_us
+        self.nEncode = summary.n_encode
+        self.tDecodeUs = summary.t_decode_us
+        self.nDecode = summary.n_decode
+        self.tPromptUs = summary.t_prompt_us
+        self.nPrompt = summary.n_prompt
+        self.tStartUs = summary.t_start_us
+        self.tEndUs = summary.t_end_us
+        self.nFailP = summary.n_fail_p
+        self.nFailH = summary.n_fail_h
+        self.tLoadUs = summary.t_load_us
+        self.tMelUs = summary.t_mel_us
+    }
+    
+    func toDictionary() -> [String: Any] {
+        return [
+            "tSampleUs": self.tSampleUs,
+            "nSample": self.nSample,
+            "tEncodeUs": self.tEncodeUs,
+            "nEncode": self.nEncode,
+            "tDecodeUs": self.tDecodeUs,
+            "nDecode": self.nDecode,
+            "tPromptUs": self.tPromptUs,
+            "nPrompt": self.nPrompt,
+            "tStartUs": self.tStartUs,
+            "tEndUs": self.tEndUs,
+            "nFailP": self.nFailP,
+            "nFailH": self.nFailH,
+            "tLoadUs": self.tLoadUs,
+            "tMelUs": self.tMelUs
+        ]
+    }
+}

--- a/macos/Classes/StreamHandlers/SummaryStreamHandler.swift
+++ b/macos/Classes/StreamHandlers/SummaryStreamHandler.swift
@@ -1,0 +1,31 @@
+import FlutterMacOS
+
+import Foundation
+import Combine
+
+class SummaryStreamHandler: NSObject, FlutterStreamHandler {
+    private var flutterEventSink: FlutterEventSink?
+    private var resultStateCancellable: AnyCancellable?
+    private let whisperState: WhisperState
+    
+    init(whisperState: WhisperState) {
+        self.whisperState = whisperState
+    }
+    
+    @MainActor
+    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        flutterEventSink = events
+        
+        resultStateCancellable = whisperState.$summary.sink { newValue in
+            self.flutterEventSink?(newValue?.toDictionary())
+        }
+        return nil
+    }
+    
+    public func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        flutterEventSink = nil
+        resultStateCancellable?.cancel()
+        resultStateCancellable = nil
+        return nil
+    }
+}

--- a/macos/Classes/WhisperCpp/WhisperState.swift
+++ b/macos/Classes/WhisperCpp/WhisperState.swift
@@ -13,6 +13,7 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
     @Published var statusLog = ""  // Log of messages for debugging and user feedback
 
     @Published var result: WhisperResult?
+    @Published var summary: WhisperSummary?
     
     
     var whisperConfig: WhisperConfig?
@@ -93,7 +94,7 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
             messageLog += "Transcribing data...\n"
             statusLog = "Transcribing data..."
             
-            await whisperContext.fullTranscribe(samples: data, state: self)
+            summary = await whisperContext.fullTranscribe(samples: data, state: self)
             let text = await whisperContext.getTranscription()
             messageLog += "Done: \(text)\n"
             statusLog = "Done."

--- a/macos/Classes/WhisperCpp/whisper.cpp/whisper.cpp
+++ b/macos/Classes/WhisperCpp/whisper.cpp/whisper.cpp
@@ -3637,8 +3637,21 @@ whisper_token whisper_token_transcribe(struct whisper_context * ctx) {
     return ctx->vocab.token_transcribe;
 }
 
-void whisper_print_timings(struct whisper_context * ctx) {
+whisper_summary whisper_print_timings(struct whisper_context * ctx) {
     const int64_t t_end_us = ggml_time_us();
+
+    whisper_summary summary;
+
+    summary.t_sample_us = ctx->state->t_sample_us;
+    summary.n_sample = std::max(1, ctx->state->n_sample);
+    summary.t_encode_us = ctx->state->t_encode_us;
+    summary.n_encode = std::max(1, ctx->state->n_encode);
+    summary.t_decode_us = ctx->state->t_decode_us;
+    summary.n_decode = std::max(1, ctx->state->n_decode);
+    summary.t_prompt_us = ctx->state->t_prompt_us;
+    summary.n_prompt = std::max(1, ctx->state->n_prompt);
+    summary.t_start_us = ctx->t_start_us;
+    summary.t_end_us = t_end_us;
 
     log("\n");
     log("%s:     load time = %8.2f ms\n", __func__, ctx->t_load_us / 1000.0f);
@@ -3657,6 +3670,8 @@ void whisper_print_timings(struct whisper_context * ctx) {
         log("%s:   prompt time = %8.2f ms / %5d runs (%8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_prompt_us, n_prompt, 1e-3f * ctx->state->t_prompt_us / n_prompt);
     }
     log("%s:    total time = %8.2f ms\n", __func__, (t_end_us - ctx->t_start_us)/1000.0f);
+
+    return summary;
 }
 
 void whisper_reset_timings(struct whisper_context * ctx) {

--- a/macos/Classes/WhisperCpp/whisper.cpp/whisper.h
+++ b/macos/Classes/WhisperCpp/whisper.cpp/whisper.h
@@ -128,6 +128,23 @@ extern "C" {
         whisper_token_data token_data;
     } whisper_result;
 
+    typedef struct whisper_summary {
+        int64_t t_sample_us;
+        int32_t n_sample;
+        int64_t t_encode_us;
+        int32_t n_encode;
+        int64_t t_decode_us;
+        int32_t n_decode;
+        int64_t t_prompt_us;
+        int32_t n_prompt;
+        int64_t t_start_us;
+        int64_t t_end_us;
+        int32_t n_fail_p;
+        int32_t n_fail_h;
+        int64_t t_load_us;
+        int64_t t_mel_us;
+    } whisper_summary;
+
     typedef struct whisper_model_loader {
         void * context;
 
@@ -347,7 +364,7 @@ extern "C" {
     WHISPER_API whisper_token whisper_token_transcribe(struct whisper_context * ctx);
 
     // Performance information from the default state.
-    WHISPER_API void whisper_print_timings(struct whisper_context * ctx);
+    WHISPER_API whisper_summary whisper_print_timings(struct whisper_context * ctx);
     WHISPER_API void whisper_reset_timings(struct whisper_context * ctx);
 
     // Print system information

--- a/macos/Classes/WhisperCppPlugin.swift
+++ b/macos/Classes/WhisperCppPlugin.swift
@@ -5,6 +5,7 @@ let kFLTWhisperCppMethodChannelName = "plugins.dagemdworku.io/whisper_cpp"
 let kFLTWhisperCppIsRecordingEvent = "whisper_cpp_is_recording_event"
 let kFLTWhisperCppStatusLogEvent = "whisper_cpp_status_log_event"
 let kFLTWhisperCppResultEvent = "whisper_cpp_result_event"
+let kFLTWhisperCppSummaryEvent = "whisper_cpp_summary_event"
 
 public class WhisperCppPlugin: NSObject, FlutterPlugin {
     private var whisperState: WhisperState?
@@ -53,6 +54,7 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
                 registerIsRecordingEventChannel(whisperState: whisperState!)
                 registerStatusLogEventChannel(whisperState: whisperState!)
                 registerResultEventChannel(whisperState: whisperState!)
+                registerSummaryEventChannel(whisperState: whisperState!)
                 
                 let whisperConfigDict: [String: Any] = [
                     "modelConfig": whisperState!.whisperConfig!.modelConfig.toDictionary(),
@@ -99,6 +101,12 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
         let eventChannelName = kFLTWhisperCppMethodChannelName + "/token/" + kFLTWhisperCppResultEvent
         let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
         eventChannel.setStreamHandler(ResultStreamHandler(whisperState: whisperState))
+    }
+    
+    private func registerSummaryEventChannel(whisperState: WhisperState) {
+        let eventChannelName = kFLTWhisperCppMethodChannelName + "/token/" + kFLTWhisperCppSummaryEvent
+        let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
+        eventChannel.setStreamHandler(SummaryStreamHandler(whisperState: whisperState))
     }
     
     private func flutterError(from error: Error) -> FlutterError {

--- a/test/whisper_cpp_test.dart
+++ b/test/whisper_cpp_test.dart
@@ -30,6 +30,10 @@ class MockWhisperCppPlatform
   @override
   // TODO: implement result
   Stream<WhisperResult?> get result => throw UnimplementedError();
+  
+  @override
+  // TODO: implement summary
+  Stream<WhisperSummary?> get summary => throw UnimplementedError();
 }
 
 void main() {


### PR DESCRIPTION
This pull request adds a new `WhisperSummary` model and performance metrics to the `WhisperCpp` class. The `WhisperSummary` model contains performance information such as the time taken for encoding, decoding, and prompting, as well as the number of samples processed. The `WhisperCpp` class now also includes a new `summary` stream that emits `WhisperSummary` objects.

This pull request includes the following commits:

* Add WhisperSummary model and performance metrics

* Add whisper_summary struct to whisper_print_timings function

* Add SummaryStreamHandler class for FlutterMacOS

* Add summary return value to fullTranscribe function

* Add summary stream to WhisperCpp

* Add summary change listener for WhisperCpp

Fixes #N/A