### PR TITLE
Add isModelLoaded and canTranscribe streams

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,6 +22,7 @@ class _MyAppState extends State<MyApp> {
 
   late StreamSubscription<bool> _isRecordingStreamSubscription;
   late StreamSubscription<bool> _isModelLoadedStreamSubscription;
+  late StreamSubscription<bool> _canTranscribeStreamSubscription;
   late StreamSubscription<dynamic> _statusLogStreamSubscription;
   late StreamSubscription<WhisperResult?> _resultStreamSubscription;
   late StreamSubscription<List<WhisperResult>> _resultsStreamSubscription;
@@ -30,6 +31,7 @@ class _MyAppState extends State<MyApp> {
   String _platformVersion = 'Unknown';
   bool _isRecording = false;
   bool _isModelLoaded = false;
+  bool _canTranscribe = false;
   String _statusLog = '';
   String _result = '';
 
@@ -68,6 +70,7 @@ class _MyAppState extends State<MyApp> {
               Text('Running on: $_platformVersion\n'),
               Text('Is Recording: $_isRecording\n'),
               Text('Is Model Loaded: $_isModelLoaded\n'),
+              Text('Can Transcribe: $_canTranscribe\n'),
               Text('Status: $_statusLog\n'),
               ElevatedButton(
                 onPressed: _initialize,
@@ -98,6 +101,7 @@ class _MyAppState extends State<MyApp> {
 
       _registerIsRecordingChangeListener();
       _registerIsModelLoadedChangeListener();
+      _registerCanTranscribeChangeListener();
       _registerStatusLogChangeListener();
       // _registerResultChangeListener();
       _registerResultsChangeListener();
@@ -122,6 +126,14 @@ class _MyAppState extends State<MyApp> {
     _isModelLoadedStreamSubscription =
         WhisperCpp.isModelLoaded.listen((bool event) {
       _isModelLoaded = event;
+      setState(() {});
+    });
+  }
+
+  void _registerCanTranscribeChangeListener() {
+    _canTranscribeStreamSubscription =
+        WhisperCpp.canTranscribe.listen((bool event) {
+      _canTranscribe = event;
       setState(() {});
     });
   }
@@ -173,6 +185,7 @@ class _MyAppState extends State<MyApp> {
   void dispose() {
     _isRecordingStreamSubscription.cancel();
     _isModelLoadedStreamSubscription.cancel();
+    _canTranscribeStreamSubscription.cancel();
     _statusLogStreamSubscription.cancel();
     _resultStreamSubscription.cancel();
     _resultsStreamSubscription.cancel();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,6 +21,7 @@ class _MyAppState extends State<MyApp> {
   final _whisperCppPlugin = WhisperCpp();
 
   late StreamSubscription<bool> _isRecordingStreamSubscription;
+  late StreamSubscription<bool> _isModelLoadedStreamSubscription;
   late StreamSubscription<dynamic> _statusLogStreamSubscription;
   late StreamSubscription<WhisperResult?> _resultStreamSubscription;
   late StreamSubscription<List<WhisperResult>> _resultsStreamSubscription;
@@ -28,6 +29,7 @@ class _MyAppState extends State<MyApp> {
 
   String _platformVersion = 'Unknown';
   bool _isRecording = false;
+  bool _isModelLoaded = false;
   String _statusLog = '';
   String _result = '';
 
@@ -65,6 +67,7 @@ class _MyAppState extends State<MyApp> {
             children: [
               Text('Running on: $_platformVersion\n'),
               Text('Is Recording: $_isRecording\n'),
+              Text('Is Model Loaded: $_isModelLoaded\n'),
               Text('Status: $_statusLog\n'),
               ElevatedButton(
                 onPressed: _initialize,
@@ -94,6 +97,7 @@ class _MyAppState extends State<MyApp> {
       print('config: ${config.toLog()}');
 
       _registerIsRecordingChangeListener();
+      _registerIsModelLoadedChangeListener();
       _registerStatusLogChangeListener();
       // _registerResultChangeListener();
       _registerResultsChangeListener();
@@ -110,6 +114,14 @@ class _MyAppState extends State<MyApp> {
     _isRecordingStreamSubscription =
         WhisperCpp.isRecording.listen((bool event) {
       _isRecording = event;
+      setState(() {});
+    });
+  }
+
+  void _registerIsModelLoadedChangeListener() {
+    _isModelLoadedStreamSubscription =
+        WhisperCpp.isModelLoaded.listen((bool event) {
+      _isModelLoaded = event;
       setState(() {});
     });
   }
@@ -160,6 +172,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void dispose() {
     _isRecordingStreamSubscription.cancel();
+    _isModelLoadedStreamSubscription.cancel();
     _statusLogStreamSubscription.cancel();
     _resultStreamSubscription.cancel();
     _resultsStreamSubscription.cancel();

--- a/lib/whisper_cpp.dart
+++ b/lib/whisper_cpp.dart
@@ -17,6 +17,10 @@ class WhisperCpp {
     return WhisperCppPlatform.instance.isModelLoaded;
   }
 
+  static Stream<bool> get canTranscribe {
+    return WhisperCppPlatform.instance.canTranscribe;
+  }
+
   static Stream<String> get statusLog {
     return WhisperCppPlatform.instance.statusLog;
   }

--- a/lib/whisper_cpp.dart
+++ b/lib/whisper_cpp.dart
@@ -9,10 +9,12 @@ export 'src/models/models.dart';
 export 'src/utils/utils.dart';
 
 class WhisperCpp {
-  
-
   static Stream<bool> get isRecording {
     return WhisperCppPlatform.instance.isRecording;
+  }
+
+  static Stream<bool> get isModelLoaded {
+    return WhisperCppPlatform.instance.isModelLoaded;
   }
 
   static Stream<String> get statusLog {

--- a/lib/whisper_cpp_method_channel.dart
+++ b/lib/whisper_cpp_method_channel.dart
@@ -7,6 +7,7 @@ import 'whisper_cpp_platform_interface.dart';
 const String _kMethodChannelName = 'plugins.dagemdworku.io/whisper_cpp';
 const String _kIsRecordingEvent = 'whisper_cpp_is_recording_event';
 const String _kIsModelLoadedEvent = 'whisper_cpp_is_model_loaded_event';
+const String _kCanTranscribeEvent = 'whisper_cpp_can_transcribe_event';
 const String _kStatusLogEvent = 'whisper_cpp_status_log_event';
 const String _kResultEvent = 'whisper_cpp_result_event';
 const String _kSummaryEvent = 'whisper_cpp_summary_event';
@@ -22,6 +23,9 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
 
   final EventChannel isModelLoadedEventChannel =
       const EventChannel('$_kMethodChannelName/token/$_kIsModelLoadedEvent');
+
+  final EventChannel canTranscribeEventChannel =
+      const EventChannel('$_kMethodChannelName/token/$_kCanTranscribeEvent');
 
   final EventChannel statusLogEventChannel =
       const EventChannel('$_kMethodChannelName/token/$_kStatusLogEvent');
@@ -67,6 +71,13 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
   }
 
   @override
+  Stream<bool> get isRecording {
+    return isRecordingEventChannel.receiveBroadcastStream().map((event) {
+      return event is bool ? event : false;
+    });
+  }
+
+  @override
   Stream<bool> get isModelLoaded {
     return isModelLoadedEventChannel.receiveBroadcastStream().map((event) {
       return event is bool ? event : false;
@@ -74,8 +85,8 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
   }
 
   @override
-  Stream<bool> get isRecording {
-    return isRecordingEventChannel.receiveBroadcastStream().map((event) {
+  Stream<bool> get canTranscribe {
+    return canTranscribeEventChannel.receiveBroadcastStream().map((event) {
       return event is bool ? event : false;
     });
   }

--- a/lib/whisper_cpp_method_channel.dart
+++ b/lib/whisper_cpp_method_channel.dart
@@ -6,6 +6,7 @@ import 'whisper_cpp_platform_interface.dart';
 
 const String _kMethodChannelName = 'plugins.dagemdworku.io/whisper_cpp';
 const String _kIsRecordingEvent = 'whisper_cpp_is_recording_event';
+const String _kIsModelLoadedEvent = 'whisper_cpp_is_model_loaded_event';
 const String _kStatusLogEvent = 'whisper_cpp_status_log_event';
 const String _kResultEvent = 'whisper_cpp_result_event';
 const String _kSummaryEvent = 'whisper_cpp_summary_event';
@@ -18,6 +19,9 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
 
   final EventChannel isRecordingEventChannel =
       const EventChannel('$_kMethodChannelName/token/$_kIsRecordingEvent');
+
+  final EventChannel isModelLoadedEventChannel =
+      const EventChannel('$_kMethodChannelName/token/$_kIsModelLoadedEvent');
 
   final EventChannel statusLogEventChannel =
       const EventChannel('$_kMethodChannelName/token/$_kStatusLogEvent');
@@ -60,6 +64,13 @@ class MethodChannelWhisperCpp extends WhisperCppPlatform {
     } on PlatformException catch (e) {
       throw WhisperCppException.mapToWhisperCppException(e.code);
     }
+  }
+
+  @override
+  Stream<bool> get isModelLoaded {
+    return isModelLoadedEventChannel.receiveBroadcastStream().map((event) {
+      return event is bool ? event : false;
+    });
   }
 
   @override

--- a/lib/whisper_cpp_platform_interface.dart
+++ b/lib/whisper_cpp_platform_interface.dart
@@ -30,6 +30,9 @@ abstract class WhisperCppPlatform extends PlatformInterface {
   Stream<bool> get isModelLoaded =>
       throw UnimplementedError('get isModelLoaded stream is not implemented');
 
+  Stream<bool> get canTranscribe =>
+      throw UnimplementedError('get canTranscribe stream is not implemented');
+
   Stream<String> get statusLog =>
       throw UnimplementedError('get statusLog stream is not implemented');
 

--- a/lib/whisper_cpp_platform_interface.dart
+++ b/lib/whisper_cpp_platform_interface.dart
@@ -27,6 +27,9 @@ abstract class WhisperCppPlatform extends PlatformInterface {
   Stream<bool> get isRecording =>
       throw UnimplementedError('get isRecording stream is not implemented');
 
+  Stream<bool> get isModelLoaded =>
+      throw UnimplementedError('get isModelLoaded stream is not implemented');
+
   Stream<String> get statusLog =>
       throw UnimplementedError('get statusLog stream is not implemented');
 
@@ -35,7 +38,7 @@ abstract class WhisperCppPlatform extends PlatformInterface {
 
   Stream<List<WhisperResult>> get results =>
       throw UnimplementedError('get results stream is not implemented');
-      
+
   Stream<WhisperSummary?> get summary =>
       throw UnimplementedError('get summary stream is not implemented');
 

--- a/macos/Classes/StreamHandlers/CanTranscribeStreamHandler.swift
+++ b/macos/Classes/StreamHandlers/CanTranscribeStreamHandler.swift
@@ -1,0 +1,31 @@
+import FlutterMacOS
+
+import Foundation
+import Combine
+
+class CanTranscribeStreamHandler: NSObject, FlutterStreamHandler {
+    private var flutterEventSink: FlutterEventSink?
+    private var recordingStateCancellable: AnyCancellable?
+    private let whisperState: WhisperState
+    
+    init(whisperState: WhisperState) {
+        self.whisperState = whisperState
+    }
+    
+    @MainActor
+    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        flutterEventSink = events
+        
+        recordingStateCancellable = whisperState.$canTranscribe.sink { newValue in
+            self.flutterEventSink?(newValue)
+        }
+        return nil
+    }
+    
+    public func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        flutterEventSink = nil
+        recordingStateCancellable?.cancel()
+        recordingStateCancellable = nil
+        return nil
+    }
+}

--- a/macos/Classes/StreamHandlers/IsModelLoadedStreamHandler.swift
+++ b/macos/Classes/StreamHandlers/IsModelLoadedStreamHandler.swift
@@ -1,0 +1,31 @@
+import FlutterMacOS
+
+import Foundation
+import Combine
+
+class IsModelLoadedStreamHandler: NSObject, FlutterStreamHandler {
+    private var flutterEventSink: FlutterEventSink?
+    private var recordingStateCancellable: AnyCancellable?
+    private let whisperState: WhisperState
+    
+    init(whisperState: WhisperState) {
+        self.whisperState = whisperState
+    }
+    
+    @MainActor
+    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        flutterEventSink = events
+        
+        recordingStateCancellable = whisperState.$isModelLoaded.sink { newValue in
+            self.flutterEventSink?(newValue)
+        }
+        return nil
+    }
+    
+    public func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        flutterEventSink = nil
+        recordingStateCancellable?.cancel()
+        recordingStateCancellable = nil
+        return nil
+    }
+}

--- a/macos/Classes/WhisperCpp/WhisperState.swift
+++ b/macos/Classes/WhisperCpp/WhisperState.swift
@@ -63,6 +63,7 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
         if let modelUrl {
             let result: WhisperConfig = try WhisperContext.createContext(path: modelUrl.path(), isDebug: isDebug)
             whisperContext = result.whisperContext
+            isModelLoaded = true
             messageLog += "Loaded model \(modelUrl.lastPathComponent)\n"
             statusLog = "Loaded model \(modelUrl.lastPathComponent)"
             return result

--- a/macos/Classes/WhisperCppPlugin.swift
+++ b/macos/Classes/WhisperCppPlugin.swift
@@ -4,6 +4,7 @@ import FlutterMacOS
 let kFLTWhisperCppMethodChannelName = "plugins.dagemdworku.io/whisper_cpp"
 let kFLTWhisperCppIsRecordingEvent = "whisper_cpp_is_recording_event"
 let kFLTWhisperCppIsModelLoadedEvent = "whisper_cpp_is_model_loaded_event"
+let kFLTWhisperCppCanTranscribeEvent = "whisper_cpp_can_transcribe_event"
 let kFLTWhisperCppStatusLogEvent = "whisper_cpp_status_log_event"
 let kFLTWhisperCppResultEvent = "whisper_cpp_result_event"
 let kFLTWhisperCppSummaryEvent = "whisper_cpp_summary_event"
@@ -59,6 +60,7 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
                 
                 registerIsRecordingEventChannel(whisperState: whisperState!)
                 registerIsModelLoadedEventChannel(whisperState: whisperState!)
+                registerCanTranscribeEventChannel(whisperState: whisperState!)
                 registerStatusLogEventChannel(whisperState: whisperState!)
                 registerResultEventChannel(whisperState: whisperState!)
                 registerSummaryEventChannel(whisperState: whisperState!)
@@ -102,6 +104,12 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
         let eventChannelName = kFLTWhisperCppMethodChannelName + "/token/" + kFLTWhisperCppIsModelLoadedEvent
         let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
         eventChannel.setStreamHandler(IsModelLoadedStreamHandler(whisperState: whisperState))
+    }
+    
+    private func registerCanTranscribeEventChannel(whisperState: WhisperState) {
+        let eventChannelName = kFLTWhisperCppMethodChannelName + "/token/" + kFLTWhisperCppCanTranscribeEvent
+        let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
+        eventChannel.setStreamHandler(CanTranscribeStreamHandler(whisperState: whisperState))
     }
     
     private func registerStatusLogEventChannel(whisperState: WhisperState) {

--- a/macos/Classes/WhisperCppPlugin.swift
+++ b/macos/Classes/WhisperCppPlugin.swift
@@ -3,6 +3,7 @@ import FlutterMacOS
 
 let kFLTWhisperCppMethodChannelName = "plugins.dagemdworku.io/whisper_cpp"
 let kFLTWhisperCppIsRecordingEvent = "whisper_cpp_is_recording_event"
+let kFLTWhisperCppIsModelLoadedEvent = "whisper_cpp_is_model_loaded_event"
 let kFLTWhisperCppStatusLogEvent = "whisper_cpp_status_log_event"
 let kFLTWhisperCppResultEvent = "whisper_cpp_result_event"
 let kFLTWhisperCppSummaryEvent = "whisper_cpp_summary_event"
@@ -57,6 +58,7 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
                 whisperState = try WhisperState(modelName: modelName, isDebug: isDebug)
                 
                 registerIsRecordingEventChannel(whisperState: whisperState!)
+                registerIsModelLoadedEventChannel(whisperState: whisperState!)
                 registerStatusLogEventChannel(whisperState: whisperState!)
                 registerResultEventChannel(whisperState: whisperState!)
                 registerSummaryEventChannel(whisperState: whisperState!)
@@ -94,6 +96,12 @@ public class WhisperCppPlugin: NSObject, FlutterPlugin {
         let eventChannelName = kFLTWhisperCppMethodChannelName + "/token/" + kFLTWhisperCppIsRecordingEvent
         let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
         eventChannel.setStreamHandler(IsRecordingStreamHandler(whisperState: whisperState))
+    }
+    
+    private func registerIsModelLoadedEventChannel(whisperState: WhisperState) {
+        let eventChannelName = kFLTWhisperCppMethodChannelName + "/token/" + kFLTWhisperCppIsModelLoadedEvent
+        let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: messenger)
+        eventChannel.setStreamHandler(IsModelLoadedStreamHandler(whisperState: whisperState))
     }
     
     private func registerStatusLogEventChannel(whisperState: WhisperState) {

--- a/test/whisper_cpp_test.dart
+++ b/test/whisper_cpp_test.dart
@@ -12,7 +12,7 @@ class MockWhisperCppPlatform
 
   @override
   // TODO: implement isRecording
-  Future<WhisperConfig> initialize({required String modelName}) =>
+  Future<WhisperConfig> initialize({required String modelName, required bool isDebug}) =>
       throw UnimplementedError();
 
   @override
@@ -34,6 +34,14 @@ class MockWhisperCppPlatform
   @override
   // TODO: implement summary
   Stream<WhisperSummary?> get summary => throw UnimplementedError();
+  
+  @override
+  // TODO: implement results
+  Stream<List<WhisperResult>> get results => throw UnimplementedError();
+  
+  @override
+  // TODO: implement isModelLoaded
+  Stream<bool> get isModelLoaded => throw UnimplementedError();
 }
 
 void main() {

--- a/test/whisper_cpp_test.dart
+++ b/test/whisper_cpp_test.dart
@@ -42,6 +42,10 @@ class MockWhisperCppPlatform
   @override
   // TODO: implement isModelLoaded
   Stream<bool> get isModelLoaded => throw UnimplementedError();
+  
+  @override
+  // TODO: implement canTranscribe
+  Stream<bool> get canTranscribe => throw UnimplementedError();
 }
 
 void main() {


### PR DESCRIPTION
This pull request adds two new streams to the WhisperCppPlatform interface: isModelLoaded and canTranscribe. These streams allow clients to monitor the loading status of the model and the ability to transcribe audio, respectively. The implementation includes changes to several files, including WhisperState, WhisperCpp, and MethodChannelWhisperCpp.

No issue number is associated with this pull request.