### PR TITLE
Add textOnly and specialCharacters getters to WhisperResult class

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -111,7 +111,8 @@ class _MyAppState extends State<MyApp> {
                   padding: const EdgeInsets.all(8.0),
                   child: Text(
                     _statusLog,
-                    style: TextStyle(color: Colors.grey.shade600, fontSize: 12.0),
+                    style:
+                        TextStyle(color: Colors.grey.shade600, fontSize: 12.0),
                   ),
                 ),
               ),
@@ -161,7 +162,9 @@ class _MyAppState extends State<MyApp> {
   }
 
   Widget _buildTranscription(List<WhisperResult> transcription) {
-    String text = transcription.map((e) => e.text).join();
+    String text = transcription.map((e) => e.textOnly).join().trim();
+    List<String> specialCharacters =
+        transcription.map((e) => e.specialCharacters).expand((e) => e).toList();
     String startTimestamp = TimestampHelper.fromInt(transcription.first.time);
     String endTimestamp = TimestampHelper.fromInt(transcription.last.time);
 
@@ -171,7 +174,7 @@ class _MyAppState extends State<MyApp> {
         Text(text.trim()),
         const SizedBox(height: 4.0),
         Text(
-          '$startTimestamp - $endTimestamp',
+          '[$startTimestamp - $endTimestamp] ${specialCharacters.join(' ')}',
           style: const TextStyle(fontSize: 12.0, color: Colors.grey),
         ),
       ],

--- a/lib/src/models/whisper_result/whisper_result.dart
+++ b/lib/src/models/whisper_result/whisper_result.dart
@@ -13,6 +13,15 @@ class WhisperResult {
     required this.tokenData,
   });
 
+  String get textOnly {
+    return text.replaceAll(RegExp(r'\[.*?\]'), '');
+  }
+
+  List<String> get specialCharacters {
+    Iterable<Match> matches = RegExp(r'\[.*?\]').allMatches(text);
+    return matches.map((m) => m.group(0)!).toList();
+  }
+
   factory WhisperResult.fromJson(Map<Object?, Object?>? data) {
     Map<String, dynamic> json = Map<String, dynamic>.from(data as Map);
 


### PR DESCRIPTION
This pull request adds two new getters to the WhisperResult class: `textOnly` and `specialCharacters`. The `textOnly` getter returns the text of the WhisperResult without any timestamps or special characters. The `specialCharacters` getter returns a list of all the special characters found in the text of the WhisperResult. Additionally, this pull request fixes formatting in the `_buildTranscription` method.